### PR TITLE
Firewall fixes - 2014.03

### DIFF
--- a/src/main/java/org/dasein/cloud/google/network/FirewallSupport.java
+++ b/src/main/java/org/dasein/cloud/google/network/FirewallSupport.java
@@ -377,18 +377,20 @@ public class FirewallSupport extends AbstractFirewallSupport {
                             String portString = "";
                             int startPort = -1;
                             int endPort = -1;
-                            for(String portRange : ports){
-                                if(portRange.contains("-")){
-                                    startPort = Integer.parseInt(portRange.split("-")[0]);
-                                    endPort = Integer.parseInt(portRange.split("-")[1]);
+                            if (ports != null) {
+                                for(String portRange : ports){
+                                    if(portRange.contains("-")){
+                                        startPort = Integer.parseInt(portRange.split("-")[0]);
+                                        endPort = Integer.parseInt(portRange.split("-")[1]);
+                                    }
+                                    else{
+                                        startPort = Integer.parseInt(portRange);
+                                        endPort = Integer.parseInt(portRange);
+                                    }
+                                    portString += portRange + "_";
                                 }
-                                else{
-                                    startPort = Integer.parseInt(portRange);
-                                    endPort = Integer.parseInt(portRange);
-                                }
-                                portString += portRange + "_";
+                                portString = portString.substring(0, portString.length()-1);//To remove trailing underscore
                             }
-                            portString = portString.substring(0, portString.length()-1);//To remove trailing underscore
 
                             final String firewallRuleId = getFirewallRuleId(firewall, sourceTarget, allowed, portString);
                             FirewallRule rule = FirewallRule.getInstance(firewallRuleId, firewall.getName(), sourceTarget, Direction.INGRESS, Protocol.valueOf(allowed.getIPProtocol().toUpperCase()), Permission.ALLOW, destinationTarget, startPort, endPort);
@@ -438,18 +440,21 @@ public class FirewallSupport extends AbstractFirewallSupport {
                             String portString = "";
                             int startPort = -1;
                             int endPort = -1;
-                            for(String portRange : ports){
-                                if(portRange.contains("-")){
-                                    startPort = Integer.parseInt(portRange.split("-")[0]);
-                                    endPort = Integer.parseInt(portRange.split("-")[1]);
+                            if (ports != null) {
+
+                                for(String portRange : ports){
+                                    if(portRange.contains("-")){
+                                        startPort = Integer.parseInt(portRange.split("-")[0]);
+                                        endPort = Integer.parseInt(portRange.split("-")[1]);
+                                    }
+                                    else{
+                                        startPort = Integer.parseInt(portRange);
+                                        endPort = Integer.parseInt(portRange);
+                                    }
+                                    portString += portRange + "_";
                                 }
-                                else{
-                                    startPort = Integer.parseInt(portRange);
-                                    endPort = Integer.parseInt(portRange);
-                                }
-                                portString += portRange + "_";
+                                portString = portString.substring(0, portString.length()-1);//To remove trailing underscore
                             }
-                            portString = portString.substring(0, portString.length()-1);//To remove trailing underscore
 
                             final String firewallRuleId = getFirewallRuleId(firewall, sourceTarget, allowed, portString);
                             FirewallRule rule = FirewallRule.getInstance(firewallRuleId, firewall.getName(), sourceTarget, Direction.INGRESS, Protocol.valueOf(allowed.getIPProtocol().toUpperCase()), Permission.ALLOW, destinationTarget, startPort, endPort);
@@ -465,18 +470,20 @@ public class FirewallSupport extends AbstractFirewallSupport {
                         String portString = "";
                         int startPort = -1;
                         int endPort = -1;
-                        for(String portRange : ports){
-                            if(portRange.contains("-")){
-                                startPort = Integer.parseInt(portRange.split("-")[0]);
-                                endPort = Integer.parseInt(portRange.split("-")[1]);
+                        if (ports != null) {
+                            for(String portRange : ports){
+                                if(portRange.contains("-")){
+                                    startPort = Integer.parseInt(portRange.split("-")[0]);
+                                    endPort = Integer.parseInt(portRange.split("-")[1]);
+                                }
+                                else{
+                                    startPort = Integer.parseInt(portRange);
+                                    endPort = Integer.parseInt(portRange);
+                                }
+                                portString += portRange + "_";
                             }
-                            else{
-                                startPort = Integer.parseInt(portRange);
-                                endPort = Integer.parseInt(portRange);
-                            }
-                            portString += portRange + "_";
+                            portString = portString.substring(0, portString.length()-1);//To remove trailing underscore
                         }
-                        portString = portString.substring(0, portString.length()-1);//To remove trailing underscore
 
                         final String firewallRuleId = getFirewallRuleId(firewall, sourceTarget, allowed, portString);
                         FirewallRule rule = FirewallRule.getInstance(firewallRuleId, firewall.getName(), sourceTarget, Direction.INGRESS, Protocol.valueOf(allowed.getIPProtocol().toUpperCase()), Permission.ALLOW, destinationTarget, startPort, endPort);


### PR DESCRIPTION
This fixes a few issues surrounding firewalls:
- Adding any new rule replaced entirely what was there before. This is because the Firewall object didn't have rules set on it.  I fixed this by adding a call to `firewall.setRules()` in `getFirewall()`. This seems reasonable as it doesn't incur any additional cloud calls.
- I also found and fixed some issues surrounding ICMP rules, where ports should not not specified or expected for allowed.
- Finally, a different ID was returned from `authorize()` than what was later returned for the new rule from `getRules()`. I fixed this to use the same ID generating method.
