### PR TITLE
BUG 4367 This allows for custom images to be removed. 

### DIFF
--- a/src/main/java/org/dasein/cloud/google/compute/server/ImageSupport.java
+++ b/src/main/java/org/dasein/cloud/google/compute/server/ImageSupport.java
@@ -239,7 +239,7 @@ public class ImageSupport extends AbstractImageSupport {
         try{
             MachineImage image = getImage(providerImageId);
             if(image.getCurrentState().equals(MachineImageState.ACTIVE)){
-                job = gce.images().delete(provider.getContext().getAccountNumber(), providerImageId).execute();
+                job = gce.images().delete(provider.getContext().getAccountNumber(), image.getName()).execute();
 
                 GoogleMethod method = new GoogleMethod(provider);
                 method.getOperationComplete(provider.getContext(), job, GoogleOperationType.GLOBAL_OPERATION, "", "");


### PR DESCRIPTION
Added StatelessImageDests.RemoveMachineImage to verify. Requires a image be
manually created first.
