### PR TITLE
Now passing more tests and compliant with the 2014.08.1 core/test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
         <groupId>org.dasein</groupId>
         <artifactId>dasein-cloud-core</artifactId>
-        <version>2014.07.1-SNAPSHOT</version>
+        <version>2014.08.1</version>
         <scope>compile</scope>
         <optional>false</optional>
     </dependency>
@@ -79,7 +79,7 @@
       <dependency>
           <groupId>org.dasein</groupId>
           <artifactId>dasein-cloud-test</artifactId>
-          <version>2014.07.1-SNAPSHOT</version>
+          <version>2014.08.1</version>
           <scope>test</scope>
           <optional>false</optional>
       </dependency>

--- a/src/main/java/org/dasein/cloud/google/DataCenters.java
+++ b/src/main/java/org/dasein/cloud/google/DataCenters.java
@@ -22,6 +22,7 @@ package org.dasein.cloud.google;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Zone;
+
 import org.apache.log4j.Logger;
 import org.dasein.cloud.CloudErrorType;
 import org.dasein.cloud.CloudException;
@@ -37,6 +38,7 @@ import org.dasein.util.uom.time.TimePeriod;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.*;
 
@@ -250,6 +252,11 @@ public class DataCenters implements DataCenterServices {
 
     @Override
     public ResourcePool getResourcePool(String providerResourcePoolId) throws InternalException, CloudException {
+        return null;
+    }
+
+    @Override
+    public Collection<StoragePool> listStoragePools() throws InternalException, CloudException {
         return null;
     }
 }

--- a/src/main/java/org/dasein/cloud/google/GoogleDataCenterCapabilities.java
+++ b/src/main/java/org/dasein/cloud/google/GoogleDataCenterCapabilities.java
@@ -30,10 +30,13 @@ public class GoogleDataCenterCapabilities extends AbstractCapabilities<Google> i
         return false;
     }
 
-
     @Override
     public boolean supportsAffinityGroups() {
-        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean supportsStoragePools() {
         return false;
     }
 }

--- a/src/main/java/org/dasein/cloud/google/capabilities/GCEInstanceCapabilities.java
+++ b/src/main/java/org/dasein/cloud/google/capabilities/GCEInstanceCapabilities.java
@@ -216,4 +216,54 @@ public class GCEInstanceCapabilities extends AbstractCapabilities<Google> implem
     public boolean supportsSpotVirtualMachines() throws InternalException, CloudException {
         return false;
     }
+
+    @Override
+    public boolean supportsAlterVM() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsClone() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsPause() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsReboot() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsResume() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsStart() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsStop() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSuspend() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsTerminate() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsUnPause() {
+        return false;
+    }
 }

--- a/src/main/java/org/dasein/cloud/google/capabilities/GCELoadBalancerCapabilities.java
+++ b/src/main/java/org/dasein/cloud/google/capabilities/GCELoadBalancerCapabilities.java
@@ -263,4 +263,9 @@ public class GCELoadBalancerCapabilities extends AbstractCapabilities<Google> im
 		return false;
 	}
 
+    @Override
+    public Requirement healthCheckRequiresName() throws CloudException, InternalException {
+        return Requirement.REQUIRED;
+    }
+
 }

--- a/src/main/java/org/dasein/cloud/google/capabilities/GCEVolumeCapabilities.java
+++ b/src/main/java/org/dasein/cloud/google/capabilities/GCEVolumeCapabilities.java
@@ -121,4 +121,28 @@ public class GCEVolumeCapabilities extends AbstractCapabilities<Google> implemen
     public @Nonnull Requirement requiresVMOnCreate() throws InternalException, CloudException {
         return Requirement.NONE;
     }
+
+    @Override
+    public int getMaximumVolumeProductIOPS() throws InternalException, CloudException {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public int getMaximumVolumeSizeIOPS() throws InternalException, CloudException {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public int getMinimumVolumeProductIOPS() throws InternalException, CloudException {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public int getMinimumVolumeSizeIOPS() throws InternalException, CloudException {
+        // TODO Auto-generated method stub
+        return 0;
+    }
 }

--- a/src/main/java/org/dasein/cloud/google/compute/server/ServerSupport.java
+++ b/src/main/java/org/dasein/cloud/google/compute/server/ServerSupport.java
@@ -312,7 +312,6 @@ public class ServerSupport extends AbstractVMSupport {
 		return listProducts(architecture, null);
 	}
 
-	@Override
 	public @Nonnull Iterable<VirtualMachineProduct> listProducts(@Nonnull Architecture architecture, String preferredDataCenterId) throws InternalException, CloudException {
         Cache<VirtualMachineProduct> cache = Cache.getInstance(provider, "ServerProducts", VirtualMachineProduct.class, CacheLevel.REGION_ACCOUNT, new TimePeriod<Day>(1, TimePeriod.DAY));
         Collection<VirtualMachineProduct> products = (Collection<VirtualMachineProduct>)cache.get(provider.getContext());
@@ -348,6 +347,11 @@ public class ServerSupport extends AbstractVMSupport {
         else return products;
 	}
 
+    @Override
+    public Iterable<VirtualMachineProduct> listProducts(VirtualMachineProductFilterOptions options, Architecture architecture) throws InternalException, CloudException{
+        return listProducts(architecture, options.getDatacenterId());
+    }
+	
 	@Override
 	public @Nonnull Iterable<VirtualMachine> listVirtualMachines(VMFilterOptions options)throws InternalException, CloudException {
         APITrace.begin(getProvider(), "listVirtualMachines");

--- a/src/main/java/org/dasein/cloud/google/platform/RDS.java
+++ b/src/main/java/org/dasein/cloud/google/platform/RDS.java
@@ -19,6 +19,7 @@ import org.dasein.cloud.platform.DatabaseEngine;
 import org.dasein.cloud.platform.DatabaseProduct;
 import org.dasein.cloud.platform.DatabaseSnapshot;
 import org.dasein.cloud.platform.DatabaseState;
+import org.dasein.cloud.platform.RelationalDatabaseCapabilities;
 import org.dasein.cloud.platform.RelationalDatabaseSupport;
 import org.dasein.cloud.util.APITrace;
 
@@ -603,6 +604,12 @@ public class RDS implements RelationalDatabaseSupport {
 
     @Override
     public Iterable<DatabaseProduct> listDatabaseProducts( DatabaseEngine forEngine ) throws CloudException, InternalException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public RelationalDatabaseCapabilities getCapabilities() throws InternalException, CloudException {
         // TODO Auto-generated method stub
         return null;
     }


### PR DESCRIPTION
Initial push to support 2014.08.1 core/test

67 failures (-3) 
