### PR TITLE
modified isSubscribed to use getSupportedVersions instead of

### DIFF
--- a/src/main/java/org/dasein/cloud/google/platform/RDS.java
+++ b/src/main/java/org/dasein/cloud/google/platform/RDS.java
@@ -736,7 +736,8 @@ public class RDS extends AbstractRelationalDatabaseSupport<Google> {
     @Override
     public boolean isSubscribed() throws CloudException, InternalException {
         try {
-            listDatabases();  // expensive call, but with caching not too bad. hope they dont beat on it.
+            getSupportedVersions(DatabaseEngine.MYSQL);
+            //listDatabases();  // expensive call, but with caching not too bad. hope they dont beat on it.
                 return true;
         } catch (Exception e) {
             // ignore. just means we are not subscribed!


### PR DESCRIPTION
listDatabases.   It is cheaper, and catches the case where cloud sql is
ENABLED, but cloud sql api is NOT enabled.  FB 5991