### PR TITLE
FB5923 trying to catch the NPE before it falls down the google NPE hole

### DIFF
--- a/src/main/java/org/dasein/cloud/google/network/LoadBalancerSupport.java
+++ b/src/main/java/org/dasein/cloud/google/network/LoadBalancerSupport.java
@@ -918,6 +918,10 @@ public class LoadBalancerSupport extends AbstractLoadBalancerSupport<Google>  {
         gce = provider.getGoogleCompute();
         ArrayList<LoadBalancer> list = new ArrayList<LoadBalancer>();
         try {
+            if (null == ctx.getAccountNumber())
+                throw new InternalException("Account number cannot be null");
+            if (null == ctx.getRegionId())
+                throw new InternalException("RegionId cannot be null");
             TargetPoolList tpl = gce.targetPools().list(ctx.getAccountNumber(), ctx.getRegionId()).execute();
 
             if ((tpl != null) && (tpl.getItems() != null)) { 


### PR DESCRIPTION
and loses all explanitory information.

Should shed more light on the issue than
https://files.slack.com/files-pri/T025ESLAP-F03KHAKH9/gcenpe.png