### PR TITLE
changed occurances of execute().getItems() to execute(); 

### DIFF
--- a/src/main/java/org/dasein/cloud/google/DataCenters.java
+++ b/src/main/java/org/dasein/cloud/google/DataCenters.java
@@ -52,6 +52,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.RegionList;
 import com.google.api.services.compute.model.Zone;
+import com.google.api.services.compute.model.ZoneList;
 
 /**
  * Implementation of GCE Regions and Zones
@@ -148,16 +149,19 @@ public class DataCenters implements DataCenterServices {
             Compute gce = provider.getGoogleCompute();
             Compute.Zones.List gceDataCenters = null;
             try{
-                List<Zone> dataCenterList = gce.zones().list(ctx.getAccountNumber()).execute().getItems();
-                for (int i=0; i < dataCenterList.size(); i++) {
-                    Zone current = dataCenterList.get(i);
+                ZoneList zoneList = gce.zones().list(ctx.getAccountNumber()).execute();
+                if (null != zoneList) {
+                    List<Zone> dataCenterList = zoneList.getItems();
+                    for (int i=0; i < dataCenterList.size(); i++) {
+                        Zone current = dataCenterList.get(i);
 
-                    String region = current.getRegion().substring(current.getRegion().lastIndexOf("/") + 1);
-                    if (region.equals(providerRegionId)) {
-                        dataCenters.add(toDataCenter(current, (null != current.getDeprecated())));
+                        String region = current.getRegion().substring(current.getRegion().lastIndexOf("/") + 1);
+                        if (region.equals(providerRegionId)) {
+                            dataCenters.add(toDataCenter(current, (null != current.getDeprecated())));
+                        }
+
+                        zone2Region.put(current.getName(), region);
                     }
-
-                    zone2Region.put(current.getName(), region);
                 }
     	    } catch (IOException ex) {
     	    	logger.error("Failed to listDataCenters: " + ex.getMessage());

--- a/src/main/java/org/dasein/cloud/google/network/NetworkSupport.java
+++ b/src/main/java/org/dasein/cloud/google/network/NetworkSupport.java
@@ -360,12 +360,15 @@ public class NetworkSupport extends AbstractVLANSupport {
         ArrayList<VLAN> vlans = new ArrayList<VLAN>();
         try{
             Compute gce = provider.getGoogleCompute();
-            List<Network> networks = gce.networks().list(ctx.getAccountNumber()).execute().getItems();
-            if (networks != null) {
-                for (Network net : networks) {
-                    VLAN vlan = toVlan(net, ctx);
-                    if(vlan != null)
-                        vlans.add(vlan);
+            NetworkList networkList = gce.networks().list(ctx.getAccountNumber()).execute();
+            if (null != networkList) {
+                List<Network> networks = networkList.getItems();
+                if (networks != null) {
+                    for (Network net : networks) {
+                        VLAN vlan = toVlan(net, ctx);
+                        if(vlan != null)
+                            vlans.add(vlan);
+                    }
                 }
             }
 	    } catch (IOException ex) {


### PR DESCRIPTION
This update should remove NPE's where execute() returns NULL, as it can, and .getItems is called on it without checking.